### PR TITLE
Improper response body

### DIFF
--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -10,13 +10,13 @@ type Handler struct {
 }
 
 type UserCreationSuccessResponse struct {
-  Code int `json:"code"`
+  Status string `json:"status"`
   Message string `json:"message"`
   UserId string `json:"userId"`
 }
 
 type UserCreationFailedResponse struct {
-  Code int `json:"code"`
+  Status string `json:"status"`
   Message string `json:"message"`
   Reason string `json:"reason"`
 }
@@ -31,11 +31,11 @@ func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&u)
 	if err != nil {
     response := UserCreationFailedResponse{
-      Code: http.StatusBadRequest,
+      Status: "Failed",
       Message: "Failed to create user",
       Reason: "Invalid request body",
     }
-		w.WriteHeader(response.Code)
+		w.WriteHeader(http.StatusBadRequest)
     w.Header().Add("Content-Type", "application/json")
     bytes, _ := json.Marshal(response)
 		w.Write(bytes)
@@ -45,11 +45,11 @@ func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 	message, err := h.Svc.AddUser(u)
 	if err != nil {
     response := UserCreationFailedResponse{
-      Code: http.StatusInternalServerError,
+      Status: "Failed",
       Message: "Failed to create user",
       Reason: "Failed to add user", // Thank you, captain obvious! :)
     }
-    w.WriteHeader(response.Code)
+    w.WriteHeader(http.StatusInternalServerError)
     w.Header().Add("Content-Type", "application/json")
     bytes, _ := json.Marshal(response)
 		w.Write(bytes)
@@ -57,11 +57,11 @@ func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 
 	// Return a success response
   response := UserCreationSuccessResponse{
-    Code: http.StatusCreated, 
+    Status: "Success", 
     Message: "New user has been created", 
     UserId: message,
   }
-	w.WriteHeader(response.Code)
+	w.WriteHeader(http.StatusCreated)
   w.Header().Add("Content-Type", "application/json")
   bytes, _ := json.Marshal(response)
 	w.Write(bytes)

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -9,6 +9,18 @@ type Handler struct {
 	Svc service
 }
 
+type UserCreationSuccessResponse struct {
+  Code int `json:"code"`
+  Message string `json:"message"`
+  UserId string `json:"userId"`
+}
+
+type UserCreationFailedResponse struct {
+  Code int `json:"code"`
+  Message string `json:"message"`
+  Reason string `json:"reason"`
+}
+
 func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -42,6 +42,13 @@ func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return a success response
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(message))
+  response := UserCreationSuccessResponse{
+    Code: http.StatusCreated, 
+    Message: "New user has been created", 
+    UserId: message,
+  }
+	w.WriteHeader(response.Code)
+  w.Header().Add("Content-Type", "application/json")
+  bytes, _ := json.Marshal(response)
+	w.Write(bytes)
 }

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -30,15 +30,29 @@ func (h Handler) AddUser(w http.ResponseWriter, r *http.Request) {
 	var u User
 	err := json.NewDecoder(r.Body).Decode(&u)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Invalid request body"))
+    response := UserCreationFailedResponse{
+      Code: http.StatusBadRequest,
+      Message: "Failed to create user",
+      Reason: "Invalid request body",
+    }
+		w.WriteHeader(response.Code)
+    w.Header().Add("Content-Type", "application/json")
+    bytes, _ := json.Marshal(response)
+		w.Write(bytes)
 		return
 	}
 	// Call the AddUser function
 	message, err := h.Svc.AddUser(u)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Failed to add user"))
+    response := UserCreationFailedResponse{
+      Code: http.StatusInternalServerError,
+      Message: "Failed to create user",
+      Reason: "Failed to add user", // Thank you, captain obvious! :)
+    }
+    w.WriteHeader(response.Code)
+    w.Header().Add("Content-Type", "application/json")
+    bytes, _ := json.Marshal(response)
+		w.Write(bytes)
 	}
 
 	// Return a success response


### PR DESCRIPTION
# Preamble
On `POST /user`, there were three kind of responses:
1. "Invalid request body" if `json` can't decode the response body
2. "Failed to add user" if there were problems on `service`
3. A user Id if user has been successfully created.

# Problem
This could be a problem in the client side where you don't have any "standards" on the response body.

Well, you could look at the status code returned by the server, 