### PR TITLE
Let credentials stored outside

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,21 +3,24 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"os"
+
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
 
-	"github.com/matthewjamesboyle/golang-interview-prep/internal/user"
 	"log"
 	"net/http"
+
+	"github.com/matthewjamesboyle/golang-interview-prep/internal/user"
 )
 
 func main() {
 
 	runMigrations()
 
-	svc, err := user.NewService("admin", "admin")
+	svc, err := user.NewService(os.Getenv("GOINTVPR_DB_USER"), os.Getenv("GOINTVPR_DB_PASSWORD"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -33,7 +36,8 @@ func main() {
 
 func runMigrations() {
 	// Database connection string
-	dbURL := "postgres://admin:admin@localhost/test_repo?sslmode=disable"
+	dbURL := fmt.Sprintf("postgres://%s:%s@localhost/test_repo?sslmode=disable",
+                       os.Getenv("GOINTVPR_DB_USER"), os.Getenv("GOINTVPR_DB_PASSWORD"))
 
 	db, err := sql.Open("postgres", dbURL)
 	if err != nil {

--- a/env.sh
+++ b/env.sh
@@ -3,4 +3,6 @@
 # Should not have this file pushed to git but
 # for demonstration purpose. This might be not 
 # the best way to store database credentials...
+# It might be better to set permission using chmod 700
+# on this file, i guess?
 alias gorun='GOINTVPR_DB_USER="admin" GOINTVPR_DB_PASSWORD="admin" go run cmd/main.go'

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+# command to run go cmd file
+# Should not have this file pushed to git but
+# for demonstration purpose. This might be not 
+# the best way to store database credentials...
+alias gorun='GOINTVPR_DB_USER="admin" GOINTVPR_DB_PASSWORD="admin" go run cmd/main.go'


### PR DESCRIPTION
Credentials should be put outside the source. This makes sure that those strings are not pushed to the source control and seen by others.

There are many ways to store credentials, one of the way I choose is to put inside environment variables. While this is not the most secure way, this hides the credential string inside the code.